### PR TITLE
添加BotController和中间件

### DIFF
--- a/Samples/Work/Senparc.Weixin.Sample.Work/Controllers/WorkBotController.cs
+++ b/Samples/Work/Senparc.Weixin.Sample.Work/Controllers/WorkBotController.cs
@@ -1,0 +1,158 @@
+﻿/*----------------------------------------------------------------
+    Copyright (C) 2025 Senparc
+    
+    文件名：WorkBotController.cs
+    文件功能描述：企业号对接测试（从QYController.cs移植）
+    
+    
+    创建标识：Senparc - 20150312
+----------------------------------------------------------------*/
+
+/*
+     重要提示
+     
+  1. 当前 Controller 展示了有特殊自定义需求的 MessageHandler 处理方案，
+     可以高度控制消息处理过程的每一个细节，
+     如果仅常规项目使用，可以直接使用中间件方式，参考 Program.cs：
+     app.UseMessageHandlerForWork("/WorkBotAsync", WorkBotCustomMessageHandler.GenerateMessageHandler, options => ...);
+
+  2. 目前 Senparc.Weixin SDK 已经全面转向异步方法驱动，
+     因此建议使用异步方法（如：messageHandler.ExecuteAsync()），不再推荐同步方法。
+
+ */
+
+
+using Microsoft.AspNetCore.Mvc;
+using Senparc.CO2NET.AspNet.HttpUtility;
+using Senparc.CO2NET.Utilities;
+using Senparc.Weixin.AspNet.MvcExtension;
+using Senparc.Weixin.Sample.Work.MessageHandlers;
+using Senparc.Weixin.Work;
+using Senparc.Weixin.Work.Entities;
+
+namespace Senparc.Weixin.Sample.Net8.Controllers
+{
+    /// <summary>
+    /// 企业号对接测试
+    /// </summary>
+    public class WorkBotController : Controller
+    {
+        public static readonly string Token = Config.SenparcWeixinSetting.WorkSetting.WeixinCorpToken;//与企业微信账号后台的Token设置保持一致，区分大小写。
+        public static readonly string EncodingAESKey = Config.SenparcWeixinSetting.WorkSetting.WeixinCorpEncodingAESKey;//与微信企业账号后台的EncodingAESKey设置保持一致，区分大小写。
+        public static readonly string CorpId = Config.SenparcWeixinSetting.WorkSetting.WeixinCorpId;//与微信企业账号后台的CorpId设置保持一致，区分大小写。
+
+        public WorkBotController()
+        {
+
+        }
+
+        /// <summary>
+        /// 微信后台验证地址（使用Get），企业微信后台应用的“修改配置”的Url填写如：https://sdk.weixin.senparc.com/WorkBot
+        /// </summary>
+        [HttpGet]
+        [ActionName("Index")]
+        public async Task<ActionResult> Get(string msg_signature = "", string timestamp = "", string nonce = "", string echostr = "")
+        {
+            //return Content(echostr); //返回随机字符串则表示验证通过
+            var verifyUrl = Signature.VerifyURL(Token, EncodingAESKey, CorpId, msg_signature, timestamp, nonce, echostr);
+            if (verifyUrl != null)
+            {
+                return Content(verifyUrl); //返回解密后的随机字符串则表示验证通过
+            }
+            else
+            {
+                return Content("如果你在浏览器中看到这句话，说明此地址可以被作为微信公众账号后台的Url，请注意保持Token一致。");
+            }
+        }
+
+        /// <summary>
+        /// 微信后台验证地址（使用Post），企业微信后台应用的“修改配置”的Url填写如：https://sdk.weixin.senparc.com/WorkBot
+        /// </summary>
+        [HttpPost]
+        [ActionName("Index")]
+        public async Task<ActionResult> Post(PostModel postModel)
+        {
+            var maxRecordCount = 10;
+
+            postModel.Token = Token;
+            postModel.EncodingAESKey = EncodingAESKey;
+            postModel.CorpId = CorpId;
+
+
+            #region 用于生产环境测试原始数据
+            //var ms = new MemoryStream();
+            //Request.InputStream.CopyTo(ms);
+            //ms.Seek(0, SeekOrigin.Begin);
+
+            //var sr = new StreamReader(ms);
+            //var xml = sr.ReadToEnd();
+            //var doc = XDocument.Parse(xml);
+            //doc.Save(ServerUtility.ContentRootMapPath("~/App_Data/TestWork.log"));
+            //return null;
+            #endregion
+
+            //自定义MessageHandler，对微信请求的详细判断操作都在这里面。
+            var messageHandler = new WorkBotCustomMessageHandler(Request.GetRequestMemoryStream(), postModel, maxRecordCount);
+
+            if (messageHandler.RequestMessage == null)
+            {
+                //验证不通过或接受信息有错误
+            }
+
+            try
+            {
+                Senparc.Weixin.WeixinTrace.SendApiLog("企业微信 Bot 收到消息", messageHandler.RequestJsonStr);
+
+                //测试时可开启此记录，帮助跟踪数据，使用前请确保App_Data文件夹存在，且有读写权限。
+                messageHandler.SaveRequestMessageLog();//记录 Request 日志（可选）
+
+                await messageHandler.ExecuteAsync(new CancellationToken());//执行微信处理过程（关键）
+
+                messageHandler.SaveResponseMessageLog();//记录 Response 日志（可选）
+
+                //自动返回加密后结果
+                return Content(messageHandler.FinalResponseJsonStr, "application/json");
+            }
+            catch (Exception ex)
+            {
+                using (TextWriter tw = new StreamWriter(ServerUtility.ContentRootMapPath("~/App_Data/Work_Error_" + SystemTime.Now.Ticks + ".txt")))
+                {
+                    tw.WriteLine("ExecptionMessage:" + ex.Message);
+                    tw.WriteLine(ex.Source);
+                    tw.WriteLine(ex.StackTrace);
+                    //tw.WriteLine("InnerExecptionMessage:" + ex.InnerException.Message);
+
+                    if (!string.IsNullOrEmpty(messageHandler.FinalResponseJsonStr))
+                    {
+                        tw.WriteLine(messageHandler.FinalResponseJsonStr);
+                    }
+                    tw.Flush();
+                    tw.Close();
+                }
+                return Content("");
+            }
+        }
+
+        /// <summary>
+        /// 这是一个最简洁的过程演示
+        /// </summary>
+        /// <param name="postModel"></param>
+        /// <returns></returns>
+        [HttpPost]
+        public async Task<ActionResult> MiniPost(PostModel postModel)
+        {
+            var maxRecordCount = 10;
+
+            postModel.Token = Token;
+            postModel.EncodingAESKey = EncodingAESKey;
+            postModel.CorpId = CorpId;
+
+            //自定义MessageHandler，对微信请求的详细判断操作都在这里面。
+            var messageHandler = new WorkBotCustomMessageHandler(Request.GetRequestMemoryStream(), postModel, maxRecordCount);
+            //执行微信处理过程
+            await messageHandler.ExecuteAsync(new CancellationToken());
+            //自动返回加密后结果
+            return Content(messageHandler.FinalResponseJsonStr, "application/json");
+        }
+    }
+}

--- a/Samples/Work/Senparc.Weixin.Sample.Work/MessageHandlers/WorkBotCustomMessageHandler.cs
+++ b/Samples/Work/Senparc.Weixin.Sample.Work/MessageHandlers/WorkBotCustomMessageHandler.cs
@@ -1,0 +1,40 @@
+using System;
+using System.IO;
+using Senparc.Weixin.Work;
+using Senparc.Weixin.Work.Entities;
+using Senparc.Weixin.Work.MessageContexts;
+using Senparc.Weixin.Work.MessageHandlers;
+
+namespace Senparc.Weixin.Sample.Work.MessageHandlers
+{
+    /// <summary>
+    /// 自定义的企业微信机器人消息处理程序
+    /// </summary>
+    public class WorkBotCustomMessageHandler : WorkBotMessageHandler<DefaultWorkMessageContext>
+    {
+        /// <summary>
+        /// 为中间件提供生成当前类的委托
+        /// </summary>
+        public static Func<Stream, PostModel, int, IServiceProvider, WorkBotCustomMessageHandler> GenerateMessageHandler =
+            (stream, postModel, maxRecordCount, serviceProvider) => new WorkBotCustomMessageHandler(stream, postModel, maxRecordCount, serviceProvider);
+
+        public WorkBotCustomMessageHandler(Stream inputStream, PostModel postModel, int maxRecordCount = 0, IServiceProvider serviceProvider = null)
+            : base(inputStream, postModel, maxRecordCount, serviceProvider: serviceProvider)
+        {
+        }
+
+        public override IWorkResponseMessageBase OnTextRequest(RequestMessageText requestMessage)
+        {
+            var responseMessage = CreateResponseMessage<ResponseMessageText>();
+            responseMessage.Content = $"您发送了消息：{requestMessage.Content}";
+            return responseMessage;
+        }
+
+        public override IWorkResponseMessageBase DefaultResponseMessage(IWorkRequestMessageBase requestMessage)
+        {
+            var responseMessage = CreateResponseMessage<ResponseMessageText>();
+            responseMessage.Content = "这是一条默认的 Bot 消息。";
+            return responseMessage;
+        }
+    }
+}

--- a/Samples/Work/Senparc.Weixin.Sample.Work/Program.cs
+++ b/Samples/Work/Senparc.Weixin.Sample.Work/Program.cs
@@ -10,12 +10,12 @@ var builder = WebApplication.CreateBuilder(args);
 // Add services to the container.
 builder.Services.AddControllersWithViews();
 
-//Ê¹ÓÃ±¾µØ»º´æ±ØĞëÌí¼Ó
+//ä½¿ç”¨æœ¬åœ°ç¼“å­˜å¿…é¡»æ·»åŠ 
 builder.Services.AddMemoryCache();
 
-#region Ìí¼ÓÎ¢ĞÅÅäÖÃ£¨Ò»ĞĞ´úÂë£©
+#region æ·»åŠ å¾®ä¿¡é…ç½®ï¼ˆä¸€è¡Œä»£ç ï¼‰
 
-//Senparc.Weixin ×¢²á£¨±ØĞë£©
+//Senparc.Weixin æ³¨å†Œï¼ˆå¿…é¡»ï¼‰
 builder.Services.AddSenparcWeixin(builder.Configuration);
 
 #endregion
@@ -23,31 +23,41 @@ builder.Services.AddSenparcWeixin(builder.Configuration);
 
 var app = builder.Build();
 
-#region ÆôÓÃÎ¢ĞÅÅäÖÃ£¨Ò»¾ä´úÂë£©
+#region å¯ç”¨å¾®ä¿¡é…ç½®ï¼ˆä¸€å¥ä»£ç ï¼‰
 
-//ÆôÓÃÎ¢ĞÅÅäÖÃ£¨±ØĞë£©
+//å¯ç”¨å¾®ä¿¡é…ç½®ï¼ˆå¿…é¡»ï¼‰
 var registerService = app.UseSenparcWeixin(app.Environment, null, null, 
     register => { },
     (register, weixinSetting) =>
 {
-    //×¢²áÆóÒµÎ¢ĞÅ£¨¿ÉÒÔÖ´ĞĞ¶à´Î£¬×¢²á¶à¸öÕËºÅ£©
-    register.RegisterWorkAccount(weixinSetting, "¡¾Ê¢ÅÉÍøÂç¡¿ÆóÒµÎ¢ĞÅ");
-});
-
-#region Ê¹ÓÃ MessageHadler ÖĞ¼ä¼ş£¬ÓÃÓÚÈ¡´ú´´½¨¶ÀÁ¢µÄ Controller
-
-//MessageHandler ÖĞ¼ä¼ş½éÉÜ£¨²Î¿¼¹«ÖÚºÅ£©£ºhttps://www.cnblogs.com/szw/p/Wechat-MessageHandler-Middleware.html
-
-//Ê¹ÓÃÆóÒµÎ¢ĞÅµÄ MessageHandler ÖĞ¼ä¼ş£¨²»ÔÙĞèÒª´´½¨ Controller£©                       --DPBMARK Work
-app.UseMessageHandlerForWork("/WorkAsync", WorkCustomMessageHandler.GenerateMessageHandler, options =>
+app.UseMessageHandlerForWork("/WorkBotAsync", WorkBotCustomMessageHandler.GenerateMessageHandler, options =>
 {
-    //»ñÈ¡Ä¬ÈÏÎ¢ĞÅÅäÖÃ
     var weixinSetting = Senparc.Weixin.Config.SenparcWeixinSetting;
 
-    //[±ØĞë] ÉèÖÃÎ¢ĞÅÅäÖÃ
     options.AccountSettingFunc = context => weixinSetting;
 
-    //[¿ÉÑ¡] ÉèÖÃ×î´óÎÄ±¾³¤¶È»Ø¸´ÏŞÖÆ£¨³¬³¤ºó»áµ÷ÓÃ¿Í·ş½Ó¿Ú·ÖÅú´Î»Ø¸´£©
+    var appKey = AccessTokenContainer.BuildingKey(weixinSetting.WorkSetting);
+    options.TextResponseLimitOptions = new TextResponseLimitOptions(2048, appKey);
+});
+
+    //æ³¨å†Œä¼ä¸šå¾®ä¿¡ï¼ˆå¯ä»¥æ‰§è¡Œå¤šæ¬¡ï¼Œæ³¨å†Œå¤šä¸ªè´¦å·ï¼‰
+    register.RegisterWorkAccount(weixinSetting, "ã€ç››æ´¾ç½‘ç»œã€‘ä¼ä¸šå¾®ä¿¡");
+});
+
+#region ä½¿ç”¨ MessageHadler ä¸­é—´ä»¶ï¼Œç”¨äºå–ä»£åˆ›å»ºç‹¬ç«‹çš„ Controller
+
+//MessageHandler ä¸­é—´ä»¶ä»‹ç»ï¼ˆå‚è€ƒå…¬ä¼—å·ï¼‰ï¼šhttps://www.cnblogs.com/szw/p/Wechat-MessageHandler-Middleware.html
+
+//ä½¿ç”¨ä¼ä¸šå¾®ä¿¡çš„ MessageHandler ä¸­é—´ä»¶ï¼ˆä¸å†éœ€è¦åˆ›å»º Controllerï¼‰                       --DPBMARK Work
+app.UseMessageHandlerForWork("/WorkAsync", WorkCustomMessageHandler.GenerateMessageHandler, options =>
+{
+    //è·å–é»˜è®¤å¾®ä¿¡é…ç½®
+    var weixinSetting = Senparc.Weixin.Config.SenparcWeixinSetting;
+
+    //[å¿…é¡»] è®¾ç½®å¾®ä¿¡é…ç½®
+    options.AccountSettingFunc = context => weixinSetting;
+
+    //[å¯é€‰] è®¾ç½®æœ€å¤§æ–‡æœ¬é•¿åº¦å›å¤é™åˆ¶ï¼ˆè¶…é•¿åä¼šè°ƒç”¨å®¢æœæ¥å£åˆ†æ‰¹æ¬¡å›å¤ï¼‰
     var appKey = AccessTokenContainer.BuildingKey(weixinSetting.WorkSetting);
     options.TextResponseLimitOptions = new TextResponseLimitOptions(2048, appKey);
 });
@@ -66,7 +76,7 @@ if (!app.Environment.IsDevelopment())
 app.UseHttpsRedirection();
 app.UseStaticFiles();
 
-#region ´Ë²¿·Ö´úÂëÎª Sample ¹²ÏíÎÄ¼şĞèÒª¶øÌí¼Ó£¬Êµ¼ÊÏîÄ¿ÎŞĞèÌí¼Ó
+#region æ­¤éƒ¨åˆ†ä»£ç ä¸º Sample å…±äº«æ–‡ä»¶éœ€è¦è€Œæ·»åŠ ï¼Œå®é™…é¡¹ç›®æ— éœ€æ·»åŠ 
 #if DEBUG
 //app.UseStaticFiles(new StaticFileOptions
 //{


### PR DESCRIPTION
## Summary
- restore Work controller's original WorkCustomMessageHandler
- expose bot logic via WorkBotController and middleware for /WorkBotAsync
- fix documentation comments referencing WorkBot endpoint

## Testing
- `dotnet build Samples/Work/Senparc.Weixin.Sample.Work.sln` *(fails: dotnet: No such file or directory)*
- `/usr/bin/apt-get update` *(fails: 403  Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c10cfb3440832c9cb76cdba04ea056